### PR TITLE
Update .gitignore to leave out the .cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@
 # npm modules
 /node_modules
 
+# Parcel cache folder
+.cache
+
 # Composer files
 /vendor


### PR DESCRIPTION
Parcel automatically creates a .cache folder in my repo, that we probably don't want there for more clarity.