### PR TITLE
Update kirbyup for compatibility with npm < 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ While kirbyup will stay backwards compatible, exact build reproducibility may be
     "build": "kirbyup src/index.js"
   },
   "devDependencies": {
-    "kirbyup": "^0.9.5"
+    "kirbyup": "^0.14.1"
   }
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import DemoSection from "./components/DemoSection.vue";
 
-panel.plugin("getkirby/pluginkit", {
+window.panel.plugin("getkirby/pluginkit", {
   sections: {
     demo: DemoSection
   }


### PR DESCRIPTION
Updates the kirbyup version in the readme example. 

Background: npm 7+ automatically installs peer dependencies, whilst npm 6 doesn't. Thus, the `vue-template-compiler` package was added to the kirbyup deps list in kirbyup 0.14.1 to fix failing builds. 